### PR TITLE
chore: set default python version in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.10
+
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"


### PR DESCRIPTION
Set default python version to 3.10 in pre-commit hooks.

This fix was suggesed by @egparedes.
