### PR TITLE
ci: Removed the MacOSX and Windows runner from the CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.12']
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It is known that DaCe does not work out of the box on [MacOSX](https://spcldace.readthedocs.io/en/latest/setup/installation.html#common-issues-with-the-dace-python-module) and [Windows](https://github.com/spcl/dace/pull/1598). Furthermore, since JaCe is a pure Python project we relay on the portability of DaCe and Jax and in the end Python. Thus every crossplatform problem should be handled by DaCe and Jax and not JaCe.
