### PR TITLE
ci: run only on linux and add pip dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,18 +36,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.12']
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+        runs-on: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+        cache: pip
+        cache-dependency-path: |
+          pyproject.toml
+          requirements/*.txt
 
     - name: Install requirementes
       run: python -m pip install -r requirements/dev.txt


### PR DESCRIPTION
Remove macos and windows hosts and add python 3.11 and dependency caching configuration in the `setup-python` step.